### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/getflow/fastapi-template/security/code-scanning/1](https://github.com/getflow/fastapi-template/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define workflow-level permissions (applies to all jobs unless overridden) with `contents: read`, which is sufficient for `actions/checkout` and the shown docker build step.

Change location: `.github/workflows/build.yaml`, near the top-level keys (after `on:` block and before `jobs:`).

No imports, methods, or dependencies are required—only YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
